### PR TITLE
Performance improvements 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
 - `git pkgs init` now installs git hooks by default (use `--no-hooks` to skip)
+- Fix N+1 queries in `blame`, `stale`, `stats`, and `log` commands
 
 ## [0.4.0] - 2026-01-04
 

--- a/lib/git/pkgs/analyzer.rb
+++ b/lib/git/pkgs/analyzer.rb
@@ -251,7 +251,7 @@ module Git
       end
 
       def parse_manifest_by_oid(blob_oid, manifest_path)
-        cache_key = "#{blob_oid}:#{manifest_path}"
+        cache_key = [blob_oid, manifest_path]
 
         if @blob_cache.key?(cache_key)
           @blob_cache[cache_key][:hits] += 1

--- a/lib/git/pkgs/commands/list.rb
+++ b/lib/git/pkgs/commands/list.rb
@@ -90,7 +90,7 @@ module Git
           # Replay changes from snapshot to target
           if snapshot_commit && snapshot_commit.id != target_commit.id
             changes = Models::DependencyChange
-              .joins(:commit, :manifest)
+              .joins(:commit)
               .where(commits: { id: branch.commit_ids })
               .where("commits.committed_at > ? AND commits.committed_at <= ?",
                      snapshot_commit.committed_at, target_commit.committed_at)

--- a/lib/git/pkgs/commands/log.rb
+++ b/lib/git/pkgs/commands/log.rb
@@ -18,6 +18,7 @@ module Git
           Database.connect(repo.git_dir)
 
           commits = Models::Commit
+            .includes(:dependency_changes)
             .where(has_dependency_changes: true)
             .order(committed_at: :desc)
 
@@ -42,8 +43,8 @@ module Git
 
         def output_text(commits)
           commits.each do |commit|
-            changes = commit.dependency_changes
-            changes = changes.where(ecosystem: @options[:ecosystem]) if @options[:ecosystem]
+            changes = commit.dependency_changes.to_a
+            changes = changes.select { |c| c.ecosystem == @options[:ecosystem] } if @options[:ecosystem]
             next if changes.empty?
 
             puts "#{commit.short_sha} #{commit.message&.lines&.first&.strip}"
@@ -75,8 +76,8 @@ module Git
           require "json"
 
           data = commits.map do |commit|
-            changes = commit.dependency_changes
-            changes = changes.where(ecosystem: @options[:ecosystem]) if @options[:ecosystem]
+            changes = commit.dependency_changes.to_a
+            changes = changes.select { |c| c.ecosystem == @options[:ecosystem] } if @options[:ecosystem]
 
             {
               sha: commit.sha,


### PR DESCRIPTION
- blame: Batch fetches all "added" changes upfront instead of one query per dependency
- stale: Same pattern - batch loads all changes and finds latest in Ruby
- stats: Single grouped query for manifest change counts instead of per-manifest queries
- log: Adds `includes(:dependency_changes)` to eager load, filters in Ruby instead of extra queries
- list: Removes unnecessary join
