### PR TITLE
Replace ActiveRecord with Sequel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,8 @@ source "https://rubygems.org"
 
 gemspec
 
-#gem "ecosystems-bibliothecary", git: "https://github.com/ecosyste-ms/bibliothecary.git", require: "bibliothecary"
+gem "ecosystems-bibliothecary", git: "https://github.com/ecosyste-ms/bibliothecary.git", require: "bibliothecary"
+# gem "ecosystems-bibliothecary", path: "/Users/andrew/code/ecosystems/bibliothecary", require: "bibliothecary"
 gem "ostruct"
 
 gem "irb"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,42 +1,7 @@
-PATH
-  remote: .
+GIT
+  remote: https://github.com/ecosyste-ms/bibliothecary.git
+  revision: 827bda17dc8866d3f712d40942760f4d52e23b63
   specs:
-    git-pkgs (0.5.0)
-      activerecord (>= 7.0)
-      ecosystems-bibliothecary (~> 15.0)
-      rugged (~> 1.0)
-      sqlite3 (>= 2.0)
-
-GEM
-  remote: https://rubygems.org/
-  specs:
-    activemodel (8.1.1)
-      activesupport (= 8.1.1)
-    activerecord (8.1.1)
-      activemodel (= 8.1.1)
-      activesupport (= 8.1.1)
-      timeout (>= 0.4.0)
-    activesupport (8.1.1)
-      base64
-      bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.3.1)
-      connection_pool (>= 2.2.5)
-      drb
-      i18n (>= 1.6, < 2)
-      json
-      logger (>= 1.4.2)
-      minitest (>= 5.1)
-      securerandom (>= 0.3)
-      tzinfo (~> 2.0, >= 2.0.5)
-      uri (>= 0.13.1)
-    base64 (0.3.0)
-    benchmark (0.5.0)
-    bigdecimal (4.0.1)
-    concurrent-ruby (1.3.6)
-    connection_pool (3.0.2)
-    csv (3.3.5)
-    date (3.5.1)
-    drb (2.2.3)
     ecosystems-bibliothecary (15.0.1)
       bundler
       csv
@@ -44,16 +9,30 @@ GEM
       ox (>= 2.8.1)
       racc
       tomlrb (~> 2.0)
+
+PATH
+  remote: .
+  specs:
+    git-pkgs (0.5.0)
+      ecosystems-bibliothecary (~> 15.0)
+      rugged (~> 1.0)
+      sequel (>= 5.0)
+      sqlite3 (>= 2.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    benchmark (0.5.0)
+    bigdecimal (4.0.1)
+    csv (3.3.5)
+    date (3.5.1)
     erb (6.0.1)
-    i18n (1.14.8)
-      concurrent-ruby (~> 1.0)
     io-console (0.8.2)
     irb (1.16.0)
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.18.0)
-    logger (1.7.0)
     minitest (6.0.1)
       prism (~> 1.5)
     ostruct (0.6.3)
@@ -75,7 +54,8 @@ GEM
     reline (0.6.3)
       io-console (~> 0.5)
     rugged (1.9.0)
-    securerandom (0.4.1)
+    sequel (5.100.0)
+      bigdecimal
     sqlite3 (2.9.0-aarch64-linux-gnu)
     sqlite3 (2.9.0-aarch64-linux-musl)
     sqlite3 (2.9.0-arm-linux-gnu)
@@ -87,12 +67,8 @@ GEM
     sqlite3 (2.9.0-x86_64-linux-gnu)
     sqlite3 (2.9.0-x86_64-linux-musl)
     stringio (3.2.0)
-    timeout (0.6.0)
     tomlrb (2.0.4)
     tsort (0.2.0)
-    tzinfo (2.0.6)
-      concurrent-ruby (~> 1.0)
-    uri (1.1.1)
 
 PLATFORMS
   aarch64-linux-gnu
@@ -108,6 +84,7 @@ PLATFORMS
 
 DEPENDENCIES
   benchmark
+  ecosystems-bibliothecary!
   git-pkgs!
   irb
   minitest
@@ -115,25 +92,16 @@ DEPENDENCIES
   rake
 
 CHECKSUMS
-  activemodel (8.1.1) sha256=8b7e2496b9e333ced06248c16a43217b950192c98e0fe3aa117eee21501c6fbd
-  activerecord (8.1.1) sha256=e32c3a03e364fd803498eb4150c21bedc995aa83bc27122a94d480ab1dcb3d17
-  activesupport (8.1.1) sha256=5e92534e8d0c8b8b5e6b16789c69dbea65c1d7b752269f71a39422e9546cea67
-  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
   bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
-  concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
-  connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
-  drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
-  ecosystems-bibliothecary (15.0.1) sha256=e557381cbe1a56931cb68c8a685a33dd9156a7b331a583874b4ac05f94df6f1c
+  ecosystems-bibliothecary (15.0.1)
   erb (6.0.1) sha256=28ecdd99c5472aebd5674d6061e3c6b0a45c049578b071e5a52c2a7f13c197e5
   git-pkgs (0.5.0)
-  i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.16.0) sha256=2abe56c9ac947cdcb2f150572904ba798c1e93c890c256f8429981a7675b0806
   json (2.18.0) sha256=b10506aee4183f5cf49e0efc48073d7b75843ce3782c68dbeb763351c08fd505
-  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   minitest (6.0.1) sha256=7854c74f48e2e975969062833adc4013f249a4b212f5e7b9d5c040bf838d54bb
   ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
   ox (2.14.23) sha256=4a9aedb4d6c78c5ebac1d7287dc7cc6808e14a8831d7adb727438f6a1b461b66
@@ -146,7 +114,7 @@ CHECKSUMS
   rdoc (7.0.3) sha256=dfe3d0981d19b7bba71d9dbaeb57c9f4e3a7a4103162148a559c4fc687ea81f9
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   rugged (1.9.0) sha256=7faaa912c5888d6e348d20fa31209b6409f1574346b1b80e309dbc7e8d63efac
-  securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
+  sequel (5.100.0) sha256=cb0329b62287a01db68eead46759c14497a3fae01b174e2c41da108a9e9b4a12
   sqlite3 (2.9.0-aarch64-linux-gnu) sha256=cfe1e0216f46d7483839719bf827129151e6c680317b99d7b8fc1597a3e13473
   sqlite3 (2.9.0-aarch64-linux-musl) sha256=56a35cb2d70779afc2ac191baf2c2148242285ecfed72f9b021218c5c4917913
   sqlite3 (2.9.0-arm-linux-gnu) sha256=a19a21504b0d7c8c825fbbf37b358ae316b6bd0d0134c619874060b2eef05435
@@ -158,11 +126,8 @@ CHECKSUMS
   sqlite3 (2.9.0-x86_64-linux-gnu) sha256=72fff9bd750070ba3af695511ba5f0e0a2d8a9206f84869640b3e99dfaf3d5a5
   sqlite3 (2.9.0-x86_64-linux-musl) sha256=ef716ba7a66d7deb1ccc402ac3a6d7343da17fac862793b7f0be3d2917253c90
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
-  timeout (0.6.0) sha256=6d722ad619f96ee383a0c557ec6eb8c4ecb08af3af62098a0be5057bf00de1af
   tomlrb (2.0.4) sha256=262f77947ac3ac9b3366a0a5940ecd238300c553e2e14f22009e2afcd2181b99
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
-  tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
-  uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH
   4.0.1

--- a/benchmark/db.rb
+++ b/benchmark/db.rb
@@ -52,11 +52,10 @@ commits.each do |rugged_commit|
   counts[:commits] += 1
 
   timings[:branch_commit_create] += Benchmark.realtime do
-    Git::Pkgs::Models::BranchCommit.find_or_create_by(
-      branch: branch,
-      commit: commit,
-      position: position
-    )
+    Git::Pkgs::Models::BranchCommit.find_or_create(
+      branch_id: branch.id,
+      commit_id: commit.id
+    ) { |bc| bc.position = position }
   end
   counts[:branch_commits] += 1
 
@@ -77,7 +76,7 @@ commits.each do |rugged_commit|
     end
 
     timings[:change_create] += Benchmark.realtime do
-      Git::Pkgs::Models::DependencyChange.create!(
+      Git::Pkgs::Models::DependencyChange.create(
         commit: commit,
         manifest: manifest,
         name: change[:name],
@@ -95,10 +94,10 @@ commits.each do |rugged_commit|
 
   snapshot.each do |(manifest_path, name), dep_info|
     timings[:snapshot_create] += Benchmark.realtime do
-      manifest = Git::Pkgs::Models::Manifest.find_by(path: manifest_path)
-      Git::Pkgs::Models::DependencySnapshot.find_or_create_by(
-        commit: commit,
-        manifest: manifest,
+      manifest = Git::Pkgs::Models::Manifest.first(path: manifest_path)
+      Git::Pkgs::Models::DependencySnapshot.find_or_create(
+        commit_id: commit.id,
+        manifest_id: manifest.id,
         name: name
       ) do |s|
         s.ecosystem = dep_info[:ecosystem]

--- a/git-pkgs.gemspec
+++ b/git-pkgs.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rugged", "~> 1.0"
-  spec.add_dependency "activerecord", ">= 7.0"
+  spec.add_dependency "sequel", ">= 5.0"
   spec.add_dependency "sqlite3", ">= 2.0"
   spec.add_dependency "ecosystems-bibliothecary", "~> 15.0"
 end

--- a/lib/git/pkgs/commands/blame.rb
+++ b/lib/git/pkgs/commands/blame.rb
@@ -19,12 +19,12 @@ module Git
 
           # Get current dependencies at the last analyzed commit
           branch_name = @options[:branch] || repo.default_branch
-          branch = Models::Branch.find_by(name: branch_name)
+          branch = Models::Branch.first(name: branch_name)
 
           error "No analysis found for branch '#{branch_name}'. Run 'git pkgs init' first." unless branch&.last_analyzed_sha
 
-          current_commit = Models::Commit.find_by(sha: branch.last_analyzed_sha)
-          snapshots = current_commit&.dependency_snapshots&.includes(:manifest) || []
+          current_commit = Models::Commit.first(sha: branch.last_analyzed_sha)
+          snapshots = current_commit&.dependency_snapshots&.eager(:manifest) || []
 
           if @options[:ecosystem]
             snapshots = snapshots.where(ecosystem: @options[:ecosystem])
@@ -41,7 +41,7 @@ module Git
           names = snapshots.map(&:name).uniq
 
           all_added_changes = Models::DependencyChange
-            .includes(:commit)
+            .eager(:commit)
             .added
             .where(manifest_id: manifest_ids, name: names)
             .to_a

--- a/lib/git/pkgs/commands/info.rb
+++ b/lib/git/pkgs/commands/info.rb
@@ -67,7 +67,7 @@ module Git
           puts "-" * 40
           total_dep_commits = Models::Commit.where(has_dependency_changes: true).count
           snapshot_commits = Models::Commit
-            .joins(:dependency_snapshots)
+            .join(:dependency_snapshots, commit_id: :id)
             .distinct
             .count
           puts "  Commits with dependency changes: #{total_dep_commits}"

--- a/lib/git/pkgs/commands/show.rb
+++ b/lib/git/pkgs/commands/show.rb
@@ -26,12 +26,14 @@ module Git
           error "Commit '#{sha[0..7]}' not in database. Run 'git pkgs update' to index new commits." unless commit
 
           changes = Models::DependencyChange
-            .includes(:commit, :manifest)
+            .eager(:commit, :manifest)
             .where(commit_id: commit.id)
 
           if @options[:ecosystem]
             changes = changes.where(ecosystem: @options[:ecosystem])
           end
+
+          changes = changes.all
 
           if changes.empty?
             empty_result "No dependency changes in #{commit.short_sha}"

--- a/lib/git/pkgs/commands/stale.rb
+++ b/lib/git/pkgs/commands/stale.rb
@@ -18,12 +18,12 @@ module Git
           Database.connect(repo.git_dir)
 
           branch_name = @options[:branch] || repo.default_branch
-          branch = Models::Branch.find_by(name: branch_name)
+          branch = Models::Branch.first(name: branch_name)
 
           error "No analysis found for branch '#{branch_name}'. Run 'git pkgs init' first." unless branch&.last_analyzed_sha
 
-          current_commit = Models::Commit.find_by(sha: branch.last_analyzed_sha)
-          snapshots = current_commit&.dependency_snapshots&.includes(:manifest) || []
+          current_commit = Models::Commit.first(sha: branch.last_analyzed_sha)
+          snapshots = current_commit&.dependency_snapshots&.eager(:manifest) || []
 
           if @options[:ecosystem]
             snapshots = snapshots.where(ecosystem: @options[:ecosystem])
@@ -40,7 +40,7 @@ module Git
           names = snapshots.map(&:name).uniq
 
           all_changes = Models::DependencyChange
-            .includes(:commit)
+            .eager(:commit)
             .where(manifest_id: manifest_ids, name: names)
             .to_a
 

--- a/lib/git/pkgs/commands/why.rb
+++ b/lib/git/pkgs/commands/why.rb
@@ -23,7 +23,7 @@ module Git
 
           # Find the first time this package was added
           added_change = Models::DependencyChange
-            .includes(:commit, :manifest)
+            .eager(:commit, :manifest)
             .for_package(package_name)
             .added
             .order("commits.committed_at ASC")

--- a/lib/git/pkgs/database.rb
+++ b/lib/git/pkgs/database.rb
@@ -1,13 +1,25 @@
 # frozen_string_literal: true
 
-require "active_record"
-require "sqlite3"
+require "sequel"
+
+# Set up a placeholder DB so models can be defined before connection
+DB = Sequel.sqlite
+Sequel::Model.plugin :timestamps, update_on_create: true
+Sequel::Model.plugin :update_or_create
+Sequel::Model.require_valid_table = false
+Sequel::Model.unrestrict_primary_key
+# Allow mass assignment of any column (similar to AR default behavior)
+Sequel::Model.strict_param_setting = false
 
 module Git
   module Pkgs
     class Database
       DB_FILE = "pkgs.sqlite3"
       SCHEMA_VERSION = 1
+
+      class << self
+        attr_accessor :db
+      end
 
       def self.path(git_dir = nil)
         return Git::Pkgs.db_path if Git::Pkgs.db_path
@@ -23,7 +35,6 @@ module Git
           raise NotInGitRepoError, "GIT_DIR '#{Git::Pkgs.git_dir}' does not exist"
         end
 
-        # Start from work_tree if set, otherwise current directory
         dir = Git::Pkgs.work_tree || Dir.pwd
         loop do
           git_dir = File.join(dir, ".git")
@@ -37,20 +48,54 @@ module Git
       end
 
       def self.connect(git_dir = nil, check_version: true)
+        disconnect
         db_path = path(git_dir)
-        ActiveRecord::Base.establish_connection(
-          adapter: "sqlite3",
-          database: db_path
-        )
+        @db = Sequel.sqlite(db_path)
+        Sequel::Model.db = @db
+        refresh_models
         check_version! if check_version
+        @db
       end
 
       def self.connect_memory
-        ActiveRecord::Base.establish_connection(
-          adapter: "sqlite3",
-          database: ":memory:"
-        )
+        disconnect
+        @db = Sequel.sqlite
+        Sequel::Model.db = @db
+        refresh_models
         create_schema
+        @db
+      end
+
+      def self.disconnect
+        return unless @db
+
+        Sequel::DATABASES.delete(@db)
+        @db.disconnect rescue nil
+        @db = nil
+      end
+
+      def self.refresh_models
+        # Force models to use the new database connection
+        [
+          Git::Pkgs::Models::Branch,
+          Git::Pkgs::Models::BranchCommit,
+          Git::Pkgs::Models::Commit,
+          Git::Pkgs::Models::Manifest,
+          Git::Pkgs::Models::DependencyChange,
+          Git::Pkgs::Models::DependencySnapshot
+        ].each do |model|
+          model.dataset = @db[model.table_name]
+          # Clear cached association datasets and loaders that may reference old db
+          model.association_reflections.each_value do |reflection|
+            if reflection[:cache]
+              reflection[:cache].delete(:_dataset)
+              reflection[:cache].delete(:associated_eager_dataset)
+              reflection[:cache].delete(:placeholder_eager_loader)
+            end
+          end
+        rescue Sequel::Error
+          # Table may not exist yet
+        end
       end
 
       def self.exists?(git_dir = nil)
@@ -58,111 +103,110 @@ module Git
       end
 
       def self.create_schema(with_indexes: true)
-        ActiveRecord::Schema.verbose = false
-        ActiveRecord::Schema.define do
-          create_table :schema_info, if_not_exists: true do |t|
-            t.integer :version, null: false
-          end
+        @db.create_table?(:schema_info) do
+          Integer :version, null: false
+        end
 
-          create_table :branches, if_not_exists: true do |t|
-            t.string :name, null: false
-            t.string :last_analyzed_sha
-            t.timestamps
-          end
-          add_index :branches, :name, unique: true, if_not_exists: true
+        @db.create_table?(:branches) do
+          primary_key :id
+          String :name, null: false
+          String :last_analyzed_sha
+          DateTime :created_at
+          DateTime :updated_at
+          index :name, unique: true
+        end
 
-          create_table :commits, if_not_exists: true do |t|
-            t.string :sha, null: false
-            t.text :message
-            t.string :author_name
-            t.string :author_email
-            t.datetime :committed_at
-            t.boolean :has_dependency_changes, default: false
-            t.timestamps
-          end
-          add_index :commits, :sha, unique: true, if_not_exists: true
+        @db.create_table?(:commits) do
+          primary_key :id
+          String :sha, null: false
+          String :message, text: true
+          String :author_name
+          String :author_email
+          DateTime :committed_at
+          TrueClass :has_dependency_changes, default: false
+          DateTime :created_at
+          DateTime :updated_at
+          index :sha, unique: true
+        end
 
-          create_table :branch_commits, if_not_exists: true do |t|
-            t.references :branch, foreign_key: true
-            t.references :commit, foreign_key: true
-            t.integer :position
-          end
-          add_index :branch_commits, [:branch_id, :commit_id], unique: true, if_not_exists: true
+        @db.create_table?(:branch_commits) do
+          primary_key :id
+          foreign_key :branch_id, :branches
+          foreign_key :commit_id, :commits
+          Integer :position
+          index [:branch_id, :commit_id], unique: true
+        end
 
-          create_table :manifests, if_not_exists: true do |t|
-            t.string :path, null: false
-            t.string :ecosystem
-            t.string :kind
-            t.timestamps
-          end
-          add_index :manifests, :path, if_not_exists: true
+        @db.create_table?(:manifests) do
+          primary_key :id
+          String :path, null: false
+          String :ecosystem
+          String :kind
+          DateTime :created_at
+          DateTime :updated_at
+          index :path
+        end
 
-          create_table :dependency_changes, if_not_exists: true do |t|
-            t.references :commit, foreign_key: true
-            t.references :manifest, foreign_key: true
-            t.string :name, null: false
-            t.string :ecosystem
-            t.string :change_type, null: false
-            t.string :requirement
-            t.string :previous_requirement
-            t.string :dependency_type
-            t.timestamps
-          end
+        @db.create_table?(:dependency_changes) do
+          primary_key :id
+          foreign_key :commit_id, :commits
+          foreign_key :manifest_id, :manifests
+          String :name, null: false
+          String :ecosystem
+          String :change_type, null: false
+          String :requirement
+          String :previous_requirement
+          String :dependency_type
+          DateTime :created_at
+          DateTime :updated_at
+        end
 
-          create_table :dependency_snapshots, if_not_exists: true do |t|
-            t.references :commit, foreign_key: true
-            t.references :manifest, foreign_key: true
-            t.string :name, null: false
-            t.string :ecosystem
-            t.string :requirement
-            t.string :dependency_type
-            t.timestamps
-          end
+        @db.create_table?(:dependency_snapshots) do
+          primary_key :id
+          foreign_key :commit_id, :commits
+          foreign_key :manifest_id, :manifests
+          String :name, null: false
+          String :ecosystem
+          String :requirement
+          String :dependency_type
+          DateTime :created_at
+          DateTime :updated_at
         end
 
         set_version
         create_bulk_indexes if with_indexes
+        refresh_models
       end
 
       def self.create_bulk_indexes
-        conn = ActiveRecord::Base.connection
+        @db.alter_table(:dependency_changes) do
+          add_index :name, if_not_exists: true
+          add_index :ecosystem, if_not_exists: true
+          add_index [:commit_id, :name], if_not_exists: true
+        end
 
-        # dependency_changes indexes
-        conn.add_index :dependency_changes, :name, if_not_exists: true
-        conn.add_index :dependency_changes, :ecosystem, if_not_exists: true
-        conn.add_index :dependency_changes, [:commit_id, :name], if_not_exists: true
-
-        # dependency_snapshots indexes
-        conn.add_index :dependency_snapshots, [:commit_id, :manifest_id, :name],
-                       unique: true, name: "idx_snapshots_unique", if_not_exists: true
-        conn.add_index :dependency_snapshots, :name, if_not_exists: true
-        conn.add_index :dependency_snapshots, :ecosystem, if_not_exists: true
+        @db.alter_table(:dependency_snapshots) do
+          add_index [:commit_id, :manifest_id, :name], unique: true, name: "idx_snapshots_unique", if_not_exists: true
+          add_index :name, if_not_exists: true
+          add_index :ecosystem, if_not_exists: true
+        end
       end
 
       def self.stored_version
-        conn = ActiveRecord::Base.connection
-        return nil unless conn.table_exists?(:schema_info)
+        return nil unless @db.table_exists?(:schema_info)
 
-        result = conn.select_value("SELECT version FROM schema_info LIMIT 1")
-        result&.to_i
+        @db[:schema_info].get(:version)
       end
 
       def self.set_version(version = SCHEMA_VERSION)
-        conn = ActiveRecord::Base.connection
-        conn.execute("DELETE FROM schema_info")
-        conn.execute("INSERT INTO schema_info (version) VALUES (#{version})")
+        @db[:schema_info].delete
+        @db[:schema_info].insert(version: version)
       end
 
       def self.needs_upgrade?
-        conn = ActiveRecord::Base.connection
+        return false unless @db.table_exists?(:commits)
+        return true unless @db.table_exists?(:schema_info)
 
-        # No tables at all = fresh database, no upgrade needed
-        return false unless conn.table_exists?(:commits)
-
-        # Has commits table but no schema_info = old database, needs upgrade
-        return true unless conn.table_exists?(:schema_info)
-
-        # Check version
         stored = stored_version || 0
         stored < SCHEMA_VERSION
       end
@@ -177,19 +221,18 @@ module Git
       end
 
       def self.optimize_for_bulk_writes
-        conn = ActiveRecord::Base.connection
-        conn.execute("PRAGMA synchronous = OFF")
-        conn.execute("PRAGMA journal_mode = WAL")
-        conn.execute("PRAGMA cache_size = -64000") # 64MB cache
+        @db.run("PRAGMA synchronous = OFF")
+        @db.run("PRAGMA journal_mode = WAL")
+        @db.run("PRAGMA cache_size = -64000")
       end
 
       def self.optimize_for_reads
-        conn = ActiveRecord::Base.connection
-        conn.execute("PRAGMA synchronous = NORMAL")
+        @db.run("PRAGMA synchronous = NORMAL")
       end
 
       def self.drop(git_dir = nil)
-        ActiveRecord::Base.connection.close if ActiveRecord::Base.connected?
+        @db&.disconnect
+        @db = nil
         File.delete(path(git_dir)) if exists?(git_dir)
       end
     end

--- a/lib/git/pkgs/models/branch.rb
+++ b/lib/git/pkgs/models/branch.rb
@@ -3,14 +3,12 @@
 module Git
   module Pkgs
     module Models
-      class Branch < ActiveRecord::Base
-        has_many :branch_commits, dependent: :destroy
-        has_many :commits, through: :branch_commits
-
-        validates :name, presence: true, uniqueness: true
+      class Branch < Sequel::Model
+        one_to_many :branch_commits
+        many_to_many :commits, join_table: :branch_commits
 
         def self.find_or_create(name)
-          find_or_create_by(name: name)
+          first(name: name) || create(name: name)
         end
       end
     end

--- a/lib/git/pkgs/models/branch_commit.rb
+++ b/lib/git/pkgs/models/branch_commit.rb
@@ -3,11 +3,9 @@
 module Git
   module Pkgs
     module Models
-      class BranchCommit < ActiveRecord::Base
-        belongs_to :branch
-        belongs_to :commit
-
-        validates :branch_id, uniqueness: { scope: :commit_id }
+      class BranchCommit < Sequel::Model
+        many_to_one :branch
+        many_to_one :commit
       end
     end
   end

--- a/lib/git/pkgs/models/commit.rb
+++ b/lib/git/pkgs/models/commit.rb
@@ -3,16 +3,17 @@
 module Git
   module Pkgs
     module Models
-      class Commit < ActiveRecord::Base
-        has_many :branch_commits, dependent: :destroy
-        has_many :branches, through: :branch_commits
-        has_many :dependency_changes, dependent: :destroy
-        has_many :dependency_snapshots, dependent: :destroy
+      class Commit < Sequel::Model
+        unrestrict_primary_key
+        plugin :validation_helpers
 
-        validates :sha, presence: true, uniqueness: true
+        one_to_many :branch_commits
+        one_to_many :dependency_changes
+        one_to_many :dependency_snapshots
+        many_to_many :branches, join_table: :branch_commits
 
         def self.find_or_create_from_rugged(rugged_commit)
-          find_or_create_by(sha: rugged_commit.oid) do |commit|
+          find_or_create(sha: rugged_commit.oid) do |commit|
             commit.message = rugged_commit.message&.strip
             commit.author_name = rugged_commit.author[:name]
             commit.author_email = rugged_commit.author[:email]
@@ -21,13 +22,13 @@ module Git
         end
 
         def self.find_or_create_from_repo(repo, sha)
-          commit = find_by(sha: sha) || where("sha LIKE ?", "#{sha}%").first
+          commit = first(sha: sha) || where(Sequel.like(:sha, "#{sha}%")).first
           return commit if commit
 
           rugged_commit = repo.lookup(sha)
           return nil unless rugged_commit
 
-          create!(
+          create(
             sha: rugged_commit.oid,
             message: rugged_commit.message,
             author_name: rugged_commit.author[:name],

--- a/lib/git/pkgs/models/dependency_change.rb
+++ b/lib/git/pkgs/models/dependency_change.rb
@@ -3,18 +3,31 @@
 module Git
   module Pkgs
     module Models
-      class DependencyChange < ActiveRecord::Base
-        belongs_to :commit
-        belongs_to :manifest
+      class DependencyChange < Sequel::Model
+        many_to_one :commit
+        many_to_one :manifest
 
-        validates :name, presence: true
-        validates :change_type, presence: true, inclusion: { in: %w[added modified removed] }
+        dataset_module do
+          def added
+            where(change_type: "added")
+          end
 
-        scope :added, -> { where(change_type: "added") }
-        scope :modified, -> { where(change_type: "modified") }
-        scope :removed, -> { where(change_type: "removed") }
-        scope :for_package, ->(name) { where(name: name) }
-        scope :for_platform, ->(platform) { where(ecosystem: platform) }
+          def modified
+            where(change_type: "modified")
+          end
+
+          def removed
+            where(change_type: "removed")
+          end
+
+          def for_package(name)
+            where(name: name)
+          end
+
+          def for_platform(platform)
+            where(ecosystem: platform)
+          end
+        end
       end
     end
   end

--- a/lib/git/pkgs/models/manifest.rb
+++ b/lib/git/pkgs/models/manifest.rb
@@ -3,17 +3,15 @@
 module Git
   module Pkgs
     module Models
-      class Manifest < ActiveRecord::Base
-        has_many :dependency_changes, dependent: :destroy
-        has_many :dependency_snapshots, dependent: :destroy
+      class Manifest < Sequel::Model
+        one_to_many :dependency_changes
+        one_to_many :dependency_snapshots
 
-        validates :path, presence: true
+        def self.find_or_create(path:, ecosystem: nil, kind: nil)
+          existing = first(path: path)
+          return existing if existing
 
-        def self.find_or_create(path:, ecosystem:, kind:)
-          find_or_create_by(path: path) do |m|
-            m.ecosystem = ecosystem
-            m.kind = kind
-          end
+          create(path: path, ecosystem: ecosystem, kind: kind)
         end
       end
     end

--- a/test/git/pkgs/test_database.rb
+++ b/test/git/pkgs/test_database.rb
@@ -35,12 +35,13 @@ class Git::Pkgs::TestDatabase < Minitest::Test
     Git::Pkgs::Database.connect(@git_dir)
     Git::Pkgs::Database.create_schema
 
-    assert ActiveRecord::Base.connection.table_exists?(:branches)
-    assert ActiveRecord::Base.connection.table_exists?(:commits)
-    assert ActiveRecord::Base.connection.table_exists?(:branch_commits)
-    assert ActiveRecord::Base.connection.table_exists?(:manifests)
-    assert ActiveRecord::Base.connection.table_exists?(:dependency_changes)
-    assert ActiveRecord::Base.connection.table_exists?(:dependency_snapshots)
+    db = Git::Pkgs::Database.db
+    assert db.table_exists?(:branches)
+    assert db.table_exists?(:commits)
+    assert db.table_exists?(:branch_commits)
+    assert db.table_exists?(:manifests)
+    assert db.table_exists?(:dependency_changes)
+    assert db.table_exists?(:dependency_snapshots)
   end
 
   def test_drop_removes_database

--- a/test/git/pkgs/test_models.rb
+++ b/test/git/pkgs/test_models.rb
@@ -71,7 +71,7 @@ class Git::Pkgs::TestModels < Minitest::Test
       kind: "manifest"
     )
 
-    Git::Pkgs::Models::DependencyChange.create!(
+    Git::Pkgs::Models::DependencyChange.create(
       commit: commit,
       manifest: manifest,
       name: "rails",
@@ -80,7 +80,7 @@ class Git::Pkgs::TestModels < Minitest::Test
       requirement: "~> 7.0"
     )
 
-    Git::Pkgs::Models::DependencyChange.create!(
+    Git::Pkgs::Models::DependencyChange.create(
       commit: commit,
       manifest: manifest,
       name: "puma",
@@ -102,7 +102,7 @@ class Git::Pkgs::TestModels < Minitest::Test
     branch = Git::Pkgs::Models::Branch.find_or_create("main")
     commit = Git::Pkgs::Models::Commit.find_or_create_from_rugged(rugged_commit)
 
-    Git::Pkgs::Models::BranchCommit.create!(
+    Git::Pkgs::Models::BranchCommit.create(
       branch: branch,
       commit: commit,
       position: 1


### PR DESCRIPTION
## Summary

- Replace ActiveRecord with Sequel ORM to reduce gem dependencies
- 32% fewer gems (41 → 28), 24% smaller lockfile
- Significant performance improvements

## Benchmark Results (octobox, 500 commits)

| Benchmark | ActiveRecord | Sequel | Improvement |
|-----------|--------------|--------|-------------|
| Full init | 6.28s | 5.33s | 15% faster |
| DB ops | 1.757s | 0.872s | 50% faster |
| Bulk insert | 0.312s | 0.200s | 36% faster |

Per-operation improvements: 46-76% faster

## Changes

- Convert all models to Sequel::Model
- Update query syntax (includes → eager, joins → eager_graph, etc.)
- Add disconnect method to properly clean up Sequel database caches
- Clear association caches in refresh_models for test isolation
- Update benchmarks for Sequel syntax

## Test plan

- [x] All 117 tests pass
- [x] Tests run consistently (no flaky tests)
- [x] Benchmarks run successfully
- [x] Tested on small repo (git-pkgs) and large repo (octobox)